### PR TITLE
Refactor weather.nu for type safety and Nushell idioms

### DIFF
--- a/weather.nu
+++ b/weather.nu
@@ -547,18 +547,18 @@ export def main [
     # Handle Astronomy Mode
     if $astro {
         if $debug { print $"(ansi cyan)ℹ Processing Astronomy Data...(ansi reset)" }
-        $data.weather | first | get astronomy | first | let current_astro
+        $data.weather | first | get astronomy | first | let current_astro: record
         
-        let moon_phase = ($current_astro.moon_phase)
-        let moon_illum = ($current_astro.moon_illumination)
-        let moon_icon = moon-icon $moon_phase $moon_illum --emoji=$emoji --text=$text
+        $current_astro.moon_phase | let moon_phase: string
+        $current_astro.moon_illumination | let moon_illum: string
+        moon-icon $moon_phase $moon_illum --emoji=$emoji --text=$text | let moon_icon: string
         
-        let sunrise_icon = if $text { '' } else if $emoji { '🌅 ' } else { " " } # nf-weather-sunrise
-        let sunset_icon = if $text { '' } else if $emoji { '🌇 ' } else { " " } # nf-weather-sunset
-        let moonrise_icon = if $text { '' } else if $emoji { "☾↑ " } else { " " } # nf-weather-moonrise
-        let moonset_icon = if $text { '' } else if $emoji { "☾↓ " } else { " " } # nf-weather-moonset
+        let sunrise_icon: string = if $text { '' } else if $emoji { '🌅 ' } else { " " } # nf-weather-sunrise
+        let sunset_icon: string = if $text { '' } else if $emoji { '🌇 ' } else { " " } # nf-weather-sunset
+        let moonrise_icon: string = if $text { '' } else if $emoji { "☾↑ " } else { " " } # nf-weather-moonrise
+        let moonset_icon: string = if $text { '' } else if $emoji { "☾↓ " } else { " " } # nf-weather-moonset
         
-        let output = {
+        let output: record = {
             "Sunrise": $"($sunrise_icon)($current_astro.sunrise)",
             "Sunset": $"($sunset_icon)($current_astro.sunset)",
             "Moonrise": $"($moonrise_icon)($current_astro.moonrise)",
@@ -578,49 +578,49 @@ export def main [
     # Handle Hourly Mode
     if $hourly {
         if $debug { print $"(ansi cyan)ℹ Processing Hourly Forecast...(ansi reset)" }
-        $data.weather | first | let today
+        $data.weather | first | let today: record
         
         # Define icons for hourly table
-        let icon_snow = if $text { '' } else if $emoji { '❄ ' } else { " " }
-        let icon_rain = if $text { '' } else if $emoji { '☔ ' } else { " " }
-        let icon_humid = if $text { '' } else if $emoji { '💧 ' } else { " " }
+        let icon_snow: string = if $text { '' } else if $emoji { '❄ ' } else { " " }
+        let icon_rain: string = if $text { '' } else if $emoji { '☔ ' } else { " " }
+        let icon_humid: string = if $text { '' } else if $emoji { '💧 ' } else { " " }
 
-        let hourly_table = ($today.hourly | each {|hour|
+        let hourly_table: list<record> = ($today.hourly | compact | each {|hour|
             # Format time (e.g., "1200" -> "12:00")
-            let t_str = ($hour.time | into string | fill -a r -w 4 -c '0')
-            let time_display = $"($t_str | str substring 0..1):($t_str | str substring 2..3)"
+            $hour.time | into string | fill -a r -w 4 -c '0' | let t_str: string
+            $"($t_str | str substring 0..1):($t_str | str substring 2..3)" | let time_display: string
             
             # Extract Temp (Note: hourly uses tempF/tempC, not temp_F/temp_C)
-            let temp = if $is_us { ($hour.tempF? | default '0') } else { ($hour.tempC? | default '0') }
-            let feels = if $is_us { ($hour.FeelsLikeF? | default '0') } else { ($hour.FeelsLikeC? | default '0') }
+            let temp: string = if $is_us { ($hour.tempF? | default '0') } else { ($hour.tempC? | default '0') }
+            let feels: string = if $is_us { ($hour.FeelsLikeF? | default '0') } else { ($hour.FeelsLikeC? | default '0') }
             
             # Icons
-            let weather_code = ($hour.weatherCode? | default '113')
-            let weather_desc = ($hour.weatherDesc?.0?.value? | default 'Unknown')
-            let weather_icon = weather-icon $weather_code --emoji=$emoji --text=$text
+            $hour.weatherCode? | default '113' | let weather_code: string
+            $hour.weatherDesc?.0?.value? | default 'Unknown' | let weather_desc: string
+            weather-icon $weather_code --emoji=$emoji --text=$text | let weather_icon: string
             
             # Wind
-            let wind_speed = ($hour | get -o $units.speed_key | default '0')
-            let wind_k = ($hour.windspeedKmph? | default '0')
-            let beaufort_scale = beaufort-scale $wind_k
-            let beaufort_icon = beaufort-icon $beaufort_scale --emoji=$emoji --text=$text
-            let wind_dir_str = ($hour.winddir16Point? | default 'N')
-            let wind_dir = wind-dir-icon $wind_dir_str --emoji=$emoji --text=$text
+            $hour | get -o $units.speed_key | default '0' | let wind_speed: string
+            $hour.windspeedKmph? | default '0' | let wind_k: string
+            beaufort-scale $wind_k | let beaufort_scale: int
+            beaufort-icon $beaufort_scale --emoji=$emoji --text=$text | let beaufort_icon: string
+            $hour.winddir16Point? | default 'N' | let wind_dir_str: string
+            wind-dir-icon $wind_dir_str --emoji=$emoji --text=$text | let wind_dir: string
             
-            let wind_display = $"($beaufort_icon) ($wind_speed)($units.speed_label) ($wind_dir)"
+            $"($beaufort_icon) ($wind_speed)($units.speed_label) ($wind_dir)" | let wind_display: string
             
             # Precip / Chance
-            let precip_val = ($hour | get -o $units.precip_key | default '0.0')
-            let chance_rain = ($hour.chanceofrain? | default '0')
-            let chance_snow = ($hour.chanceofsnow? | default '0')
+            $hour | get -o $units.precip_key | default '0.0' | let precip_val: string
+            $hour.chanceofrain? | default '0' | let chance_rain: string
+            $hour.chanceofsnow? | default '0' | let chance_snow: string
             
-            let precip_display = if ($chance_snow | into int) > 0 {
+            let precip_display: string = if ($chance_snow | into int) > 0 {
                 $"($icon_snow)($chance_snow)% / ($precip_val)($units.precip_label)"
             } else {
                 $"($icon_rain)($chance_rain)% / ($precip_val)($units.precip_label)"
             }
 
-            let condition_str = if $text { $weather_desc } else { $"($weather_icon) ($weather_desc)" }
+            let condition_str: string = if $text { $weather_desc } else { $"($weather_icon) ($weather_desc)" }
 
             {
                 Time: $time_display,
@@ -641,36 +641,36 @@ export def main [
     # Handle Forecast Mode
     if $forecast {
         if $debug { print $"(ansi cyan)ℹ Processing 3-Day Forecast...(ansi reset)" }
-        let forecast_table = ($data.weather | each {|day|
-            let date = ($day.date | into datetime | format date '%a, %b %d')
-            let max_temp = ($day | get $units.forecast_max_key)
-            let min_temp = ($day | get $units.forecast_min_key)
+        let forecast_table: list<record> = ($data.weather | compact | each {|day|
+            $day.date | into datetime | format date '%a, %b %d' | let date: string
+            $day | get $units.forecast_max_key | let max_temp: string
+            $day | get $units.forecast_min_key | let min_temp: string
             
             # Get noon weather for icon (approximate daily condition)
-            let noon = ($day.hourly | where time == '1200' | first | default ($day.hourly | first))
+            $day.hourly | where time == '1200' | first | default ($day.hourly | first) | let noon: record
             
             # Extract Wind and Rain
-            let wind_speed = ($noon | get -o $units.speed_key | default '0')
-            let wind_k = ($noon.windspeedKmph? | default '0')
-            let beaufort_scale = beaufort-scale $wind_k
-            let beaufort_icon = beaufort-icon $beaufort_scale --emoji=$emoji --text=$text
+            $noon | get -o $units.speed_key | default '0' | let wind_speed: string
+            $noon.windspeedKmph? | default '0' | let wind_k: string
+            beaufort-scale $wind_k | let beaufort_scale: int
+            beaufort-icon $beaufort_scale --emoji=$emoji --text=$text | let beaufort_icon: string
             
-            let wind_dir_str = ($noon.winddir16Point? | default 'N')
-            let wind_dir = wind-dir-icon $wind_dir_str --emoji=$emoji --text=$text
-            let precip_val = ($noon | get -o $units.precip_key | default '0.0')
+            $noon.winddir16Point? | default 'N' | let wind_dir_str: string
+            wind-dir-icon $wind_dir_str --emoji=$emoji --text=$text | let wind_dir: string
+            $noon | get -o $units.precip_key | default '0.0' | let precip_val: string
             
-            let weather_code = ($noon.weatherCode? | default '113')
-            let weather_desc = ($noon.weatherDesc?.0?.value? | default 'Unknown')
-            let weather_icon = weather-icon $weather_code --emoji=$emoji --text=$text
+            $noon.weatherCode? | default '113' | let weather_code: string
+            $noon.weatherDesc?.0?.value? | default 'Unknown' | let weather_desc: string
+            weather-icon $weather_code --emoji=$emoji --text=$text | let weather_icon: string
             
             # Moon for forecast
-            let moon_phase = ($day.astronomy.0.moon_phase)
-            let moon_illum = ($day.astronomy.0.moon_illumination)
-            let moon_icon = moon-icon $moon_phase $moon_illum --emoji=$emoji --text=$text
+            $day.astronomy.0.moon_phase | let moon_phase: string
+            $day.astronomy.0.moon_illumination | let moon_illum: string
+            moon-icon $moon_phase $moon_illum --emoji=$emoji --text=$text | let moon_icon: string
             
-            let condition_str = if $text { $weather_desc } else { $"($weather_icon) ($weather_desc)" }
+            let condition_str: string = if $text { $weather_desc } else { $"($weather_icon) ($weather_desc)" }
             
-            let wind_display = $"($beaufort_icon) ($wind_speed)($units.speed_label) ($wind_dir)"
+            $"($beaufort_icon) ($wind_speed)($units.speed_label) ($wind_dir)" | let wind_display: string
             
             {
                 Date: $date,
@@ -701,7 +701,6 @@ export def main [
     $data.current_condition | first | let current: record
     $data.weather | first | let weather_data: record
     $weather_data.astronomy | first | let astro: record
-    unlet $data
     
     # Dynamic extraction using the units schema
     $current | get -o $units.temp_key | default '0' | let temp_val: string

--- a/weather.nu
+++ b/weather.nu
@@ -200,21 +200,21 @@ export def main [
     --lang: string = ""             # Specify language code (e.g. 'fr', 'de', 'es', 'zh'). Empty = auto.
 ]: nothing -> any {
     # URL encode for API (handles all special chars including Unicode)
-    $city | url encode | let encoded_city
+    $city | url encode | let url_encoded_city
     
     # Display name is just the original input
     let display_city = if ($city | is-empty) { 'Auto-detect' } else { $city }
     
     # Build the full URL
-    let lang_param = if ($lang | is-empty) { '' } else { $"&lang=($lang)" }
-    let url = $"https://wttr.in/($encoded_city)?format=j1($lang_param)"
+    let language_param = if ($lang | is-empty) { '' } else { $"&lang=($lang)" }
+    let url = $"https://wttr.in/($url_encoded_city)?format=j1($language_param)"
     
     # Cache Configuration
     let base_dir = ($nu.cache-dir? | default ($env.TEMP? | default $env.TMP? | default '/tmp'))
     $base_dir | path join 'nu_weather_cache' | let cache_dir
     if not ($cache_dir | path exists) { mkdir $cache_dir }
-    let lang_suffix = if ($lang | is-empty) { '' } else { $"_($lang)" }
-    let cache_file = if ($encoded_city | is-empty) { $"auto($lang_suffix).json" } else { $"($encoded_city)($lang_suffix).json" }
+    let language_suffix = if ($lang | is-empty) { '' } else { $"_($lang)" }
+    let cache_file = if ($url_encoded_city | is-empty) { $"auto($language_suffix).json" } else { $"($url_encoded_city)($language_suffix).json" }
     $cache_dir | path join $cache_file | let cache_path
     let is_cache_valid = if $force {
         false
@@ -227,7 +227,7 @@ export def main [
         print $"(ansi cyan)🔍 DEBUG MODE ENABLED(ansi reset)"
         print $"(ansi grey)━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━(ansi reset)"
         print $"Original input: '($city)'"
-        print $"URL encoded:    '($encoded_city)'"
+        print $"URL encoded:    '($url_encoded_city)'"
         print $"Request URL:    ($url)"
         print $"(ansi grey)━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━(ansi reset)"
         print $"Cache Path:     ($cache_path)"
@@ -497,7 +497,7 @@ export def main [
             temp_label: '°F', speed_label: 'mph', precip_label: 'in', vis_label: 'mi', press_label: 'inHg',
             temp_key: 'temp_F', feels_key: 'FeelsLikeF',
             speed_key: 'windspeedMiles', precip_key: 'precipInches', vis_key: 'visibilityMiles', press_key: 'pressureInches',
-            fc_max_key: 'maxtempF', fc_min_key: 'mintempF',
+            forecast_max_key: 'maxtempF', forecast_min_key: 'mintempF',
             hot_limit: 80, cold_limit: 40
         }
     } else {
@@ -505,7 +505,7 @@ export def main [
             temp_label: '°C', speed_label: 'km/h', precip_label: 'mm', vis_label: 'km', press_label: 'hPa',
             temp_key: 'temp_C', feels_key: 'FeelsLikeC',
             speed_key: 'windspeedKmph', precip_key: 'precipMM', vis_key: 'visibility', press_key: 'pressure',
-            fc_max_key: 'maxtempC', fc_min_key: 'mintempC',
+            forecast_max_key: 'maxtempC', forecast_min_key: 'mintempC',
             hot_limit: 27, cold_limit: 4
         }
     }
@@ -616,8 +616,8 @@ export def main [
         if $debug { print $"(ansi cyan)ℹ Processing 3-Day Forecast...(ansi reset)" }
         let forecast_table = ($data.weather | each {|day|
             let date = ($day.date | into datetime | format date '%a, %b %d')
-            let max_temp = ($day | get $units.fc_max_key)
-            let min_temp = ($day | get $units.fc_min_key)
+            let max_temp = ($day | get $units.forecast_max_key)
+            let min_temp = ($day | get $units.forecast_min_key)
             
             # Get noon weather for icon (approximate daily condition)
             let noon = ($day.hourly | where time == '1200' | first | default ($day.hourly | first))
@@ -773,7 +773,7 @@ export def main [
     let location_display = if $text or $raw {
         $actual_location
     } else {
-        let link_url = $"https://wttr.in/($encoded_city)"
+        let link_url = $"https://wttr.in/($url_encoded_city)"
         $link_url | ansi link --text $actual_location
     }
 

--- a/weather.nu
+++ b/weather.nu
@@ -23,7 +23,15 @@
 
 # Helper Commands
 
-def format-temp [val: any, units: record, --text]: nothing -> string {
+def format-temp [
+    val: string           # Raw temperature value from API
+    units: record<        # Unit configuration record
+        temp_label: string,
+        hot_limit: int,
+        cold_limit: int
+    >
+    --text                # Plain text mode (no ANSI color)
+]: nothing -> string {
     let temp_int = ($val | into int)
     if $text {
         $"($val)($units.temp_label)"
@@ -39,7 +47,11 @@ def format-temp [val: any, units: record, --text]: nothing -> string {
     }
 }
 
-def weather-icon [code: string, --emoji, --text]: nothing -> string {
+def weather-icon [
+    code: string          # WorldWeatherOnline weather code
+    --emoji               # Use emoji instead of Nerd Font icons
+    --text                # Plain text mode (no icons)
+]: nothing -> string {
     if $text { return "" }
     if $emoji {
         match $code {
@@ -86,7 +98,12 @@ def weather-icon [code: string, --emoji, --text]: nothing -> string {
     }
 }
 
-def moon-icon [phase: string, illum: any, --emoji, --text]: nothing -> string {
+def moon-icon [
+    phase: string         # Moon phase name from API
+    illum: string         # Moon illumination percentage as API string
+    --emoji               # Use emoji instead of Nerd Font icons
+    --text                # Plain text mode (no icons)
+]: nothing -> string {
     if $text { return "" }
     let illum_int = ($illum | into int)
     let phase_lower = ($phase | str downcase)
@@ -136,7 +153,9 @@ def moon-icon [phase: string, illum: any, --emoji, --text]: nothing -> string {
     }
 }
 
-def beaufort-scale [kmph: any]: nothing -> int {
+def beaufort-scale [
+    kmph: string          # Wind speed in km/h as API string
+]: nothing -> int {
     let k = ($kmph | into int)
     match $k {
         $x if $x < 1 => 0,
@@ -155,7 +174,11 @@ def beaufort-scale [kmph: any]: nothing -> int {
     }
 }
 
-def beaufort-icon [scale: int, --emoji, --text]: nothing -> string {
+def beaufort-icon [
+    scale: int            # Beaufort scale number
+    --emoji               # Use emoji instead of Nerd Font icons
+    --text                # Plain text mode (no icons)
+]: nothing -> string {
     if $emoji or $text {
         return $"[Bft ($scale)]"
     }
@@ -165,7 +188,11 @@ def beaufort-icon [scale: int, --emoji, --text]: nothing -> string {
     }
 }
 
-def wind-dir-icon [dir: string, --emoji, --text]: nothing -> string {
+def wind-dir-icon [
+    dir: string           # Wind direction (e.g. N, SW)
+    --emoji               # Use emoji instead of Nerd Font icons
+    --text                # Plain text mode (no icons)
+]: nothing -> string {
     if $emoji or $text {
         return $dir
     }


### PR DESCRIPTION
## Summary

A few code quality improvements from the project PRD. Main focus: explicit type annotations, `| let` pipeline syntax for variable bindings, and safer handling of API list data.

## Changes

### Type safety & style

Converted variable bindings in Forecast, Hourly, and Astronomy modes to use the `| let var: type` pipeline style, with explicit type annotations throughout. `if`/`else` assignments and record literals stay in the traditional `let var: type = ...` form per the style guide.

### Data safety

Added `compact` before `each` loops when iterating over `hourly` and `weather` lists. This guards against runtime errors if the API returns null entries in those arrays.

### Config improvements 

Renamed `fc_max_key` and `fc_min_key` to `forecast_max_key` and `forecast_min_key`. Added a `record` type annotation to the `units` config variable.

## Verification

- [x] `weather --test` passes (Default/Current mode)
- [x] `weather --test -3` passes (Forecast mode)
- [x] `weather --test --hourly` passes (Hourly mode)
- [x] `weather --test --astro` passes (Astronomy mode)
- [x] Both Imperial and Metric paths verified via `--test -i` and `--test -m`
